### PR TITLE
main.py: add Ctrl+, to open settings

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -48,7 +48,9 @@ class MonitorApplication(Adw.Application):
         self.create_action("quit", self.on_quit, ["<primary>q"])
         self.create_action("about", self.on_about_action)
         self.create_action("tips", self.on_tips_action)
-        self.create_action("preferences", self.on_preferences_action, ["<primary>comma"])
+        self.create_action(
+            "preferences", self.on_preferences_action, ["<primary>comma"]
+        )
 
         self._discover_dynamic_monitors()
 

--- a/src/main.py
+++ b/src/main.py
@@ -48,7 +48,7 @@ class MonitorApplication(Adw.Application):
         self.create_action("quit", self.on_quit, ["<primary>q"])
         self.create_action("about", self.on_about_action)
         self.create_action("tips", self.on_tips_action)
-        self.create_action("preferences", self.on_preferences_action)
+        self.create_action("preferences", self.on_preferences_action, ["<primary>comma"])
 
         self._discover_dynamic_monitors()
 


### PR DESCRIPTION
<!-- Hello! Please try to answer the following questions so that a reviewer can better understand the changes proposed in this PR.
Thank you :) -->

## What?
<!-- Please describe the change introduced in this PR -->
The keyboard shortcut `Ctrl`+`,` opens the preferences window.

Closes #59 

## Why?
<!-- Please explain the motivation behind this change -->
It's convenient.

## How could a reviewer see this new change in action?
<!-- Try to give a hint on how a reviewer could easily take a look at the change introduced in this PR -->
Run 
```bash
git clone -b settings-shortcut https://gregorni/monitorets
```
then run with GNOME Builder.