### PR TITLE
data: Mark release descriptions as untranslatable

### DIFF
--- a/data/io.github.jorchube.monitorets.appdata.xml.in
+++ b/data/io.github.jorchube.monitorets.appdata.xml.in
@@ -66,21 +66,21 @@
       </description>
     </release>
     <release version="0.9.2" date="2023-02-11">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Fix misalignment of monitor titles</li>
         </ul>
       </description>
     </release>
     <release version="0.9.1" date="2023-02-04">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added missing filesystem permissions</li>
         </ul>
       </description>
     </release>
     <release version="0.9.0" date="2023-02-03">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added support for arbitrarily large monitor size</li>
           <li>Added support to arrange monitors in a grid layout</li>
@@ -92,7 +92,7 @@
       </description>
     </release>
     <release version="0.8.0" date="2023-01-21">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added support to show the current value of a monitor</li>
           <li>Remember window size on close</li>
@@ -101,14 +101,14 @@
       </description>
     </release>
     <release version="0.7.1" date="2023-01-11">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Fixed a bug preventing the preferences window from opening (Thanks to @jrdmellow)</li>
         </ul>
       </description>
     </release>
     <release version="0.7.0" date="2023-01-06">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added support for custom monitor names</li>
           <li>Added smooth graph drawing</li>
@@ -116,7 +116,7 @@
       </description>
     </release>
     <release version="0.6.90" date="2022-12-27">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added Swap memory monitor</li>
           <li>Refactored dropdown menu and preferences</li>
@@ -124,28 +124,28 @@
       </description>
     </release>
     <release version="0.6.1" date="2022-12-09">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added Dutch language support</li>
         </ul>
       </description>
     </release>
     <release version="0.6.0" date="2022-12-02">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added internationalization support</li>
         </ul>
       </description>
     </release>
     <release version="0.5.1" date="2022-11-21">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Restored missing network permission needed for the network monitors</li>
         </ul>
       </description>
     </release>
     <release version="0.5.0" date="2022-11-20">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Autodiscover temperature sensors and expose them as temperature monitors</li>
           <li>Ellipsize monitor names when do not fit the available space</li>
@@ -154,7 +154,7 @@
       </description>
     </release>
     <release version="0.4.0" date="2022-11-17">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added network downlink and uplink traffic monitors</li>
           <li>Some cosmetic changes have been done</li>
@@ -162,7 +162,7 @@
       </description>
     </release>
     <release version="0.3.0" date="2022-11-06">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added home and root folder usage monitors</li>
           <li>Added layout selector</li>
@@ -172,12 +172,12 @@
       </description>
     </release>
     <release version="0.2.1" date="2022-11-02">
-      <description>
+      <description translatable="no">
         <p>Under the hood tweaks</p>
       </description>
     </release>
     <release version="0.2.0" date="2022-11-01">
-      <description>
+      <description translatable="no">
         <p>Aesthetic:</p>
         <p>  - Reworked graph drawing</p>
         <p>Internal:</p>
@@ -185,7 +185,7 @@
       </description>
     </release>
     <release version="0.1.0" date="2022-10-31">
-      <description>
+      <description translatable="no">
         <p>First release</p>
       </description>
     </release>

--- a/data/io.github.jorchube.monitorets.appdata.xml.in
+++ b/data/io.github.jorchube.monitorets.appdata.xml.in
@@ -8,6 +8,8 @@
   <developer_name>Jordi Chulia</developer_name>
   <url type="homepage">https://github.com/jorchube/monitorets/</url>
   <url type="bugtracker">https://github.com/jorchube/monitorets/issues</url>
+  <url type="translate">https://github.com/jorchube/monitorets/po/</url>
+  <url type="vcs-browser">https://github.com/jorchube/monitorets/</url>
 
   <content_rating type="oars-1.1" />
 

--- a/po/monitorets.pot
+++ b/po/monitorets.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: monitorets\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-23 11:29+0300\n"
+"POT-Creation-Date: 2023-10-12 20:25+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,7 +23,7 @@ msgid "Monitorets"
 msgstr ""
 
 #: data/io.github.jorchube.monitorets.appdata.xml.in:5
-#: data/io.github.jorchube.monitorets.appdata.xml.in:15
+#: data/io.github.jorchube.monitorets.appdata.xml.in:17
 msgid "Have always at a glance the usage of system resources"
 msgstr ""
 
@@ -31,212 +31,67 @@ msgstr ""
 msgid "Jordi Chulia"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:17
+#: data/io.github.jorchube.monitorets.appdata.xml.in:19
 msgid ""
 "Monitorets is a small utility application offering a simple and quick view "
 "at the usage of several of your computer resources. Almost like an applet or "
 "a widget for your desktop."
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:19
+#: data/io.github.jorchube.monitorets.appdata.xml.in:21
 msgid "Available monitors:"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:21
+#: data/io.github.jorchube.monitorets.appdata.xml.in:23
 #: src/translatable_strings/monitor_title.py:3
 #: src/translatable_strings/preference_toggle_label.py:3
 #: src/translatable_strings/preference_toggle_section_name.py:3
 msgid "CPU"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:22
+#: data/io.github.jorchube.monitorets.appdata.xml.in:24
 msgid "GPU (experimental support)"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:23
+#: data/io.github.jorchube.monitorets.appdata.xml.in:25
 #: src/translatable_strings/monitor_title.py:5
 #: src/translatable_strings/preference_toggle_label.py:6
 #: src/translatable_strings/preference_toggle_section_name.py:5
 msgid "Memory"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:24
+#: data/io.github.jorchube.monitorets.appdata.xml.in:26
 #: src/translatable_strings/monitor_title.py:6
 #: src/translatable_strings/preference_toggle_label.py:7
 msgid "Swap"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:25
+#: data/io.github.jorchube.monitorets.appdata.xml.in:27
 msgid "Network downlink traffic"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:26
+#: data/io.github.jorchube.monitorets.appdata.xml.in:28
 msgid "Network uplink traffic"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:27
+#: data/io.github.jorchube.monitorets.appdata.xml.in:29
 msgid "Home folder space"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:28
+#: data/io.github.jorchube.monitorets.appdata.xml.in:30
 msgid "Root space"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:29
+#: data/io.github.jorchube.monitorets.appdata.xml.in:31
 msgid "CPU, Memory and I/O pressure"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:30
+#: data/io.github.jorchube.monitorets.appdata.xml.in:32
 msgid "Temperature sensors"
 msgstr ""
 
-#: data/io.github.jorchube.monitorets.appdata.xml.in:62
+#: data/io.github.jorchube.monitorets.appdata.xml.in:64
 msgid "Added CPU, Memory and I/O pressure monitors"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:69
-msgid "Fix misalignment of monitor titles"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:76
-msgid "Added missing filesystem permissions"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:83
-msgid "Added support for arbitrarily large monitor size"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:84
-msgid "Added support to arrange monitors in a grid layout"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:85
-msgid ""
-"Added support to select between Celsius and Fahrenheit units for the "
-"temperature sensors"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:86
-msgid "Added support to configure the redraw rate of the monitor graphs"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:87
-msgid ""
-"Added a keyboard shortcut to open the preferences window (Kudos to github."
-"com/gregorni/)"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:88
-msgid "Added french translation (Kudos to github.com/rene-coty/)"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:95
-msgid "Added support to show the current value of a monitor"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:96
-msgid "Remember window size on close"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:97
-msgid ""
-"Use the same scaling for network uplink and downlink monitors to avoid "
-"confusion"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:104
-msgid ""
-"Fixed a bug preventing the preferences window from opening (Thanks to "
-"@jrdmellow)"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:111
-msgid "Added support for custom monitor names"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:112
-msgid "Added smooth graph drawing"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:119
-msgid "Added Swap memory monitor"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:120
-msgid "Refactored dropdown menu and preferences"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:127
-msgid "Added Dutch language support"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:134
-msgid "Added internationalization support"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:141
-msgid "Restored missing network permission needed for the network monitors"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:148
-msgid ""
-"Autodiscover temperature sensors and expose them as temperature monitors"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:149
-msgid "Ellipsize monitor names when do not fit the available space"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:150
-msgid "Add monitor groups for same-kind monitors in the preferences popover"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:157
-msgid "Added network downlink and uplink traffic monitors"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:158
-msgid "Some cosmetic changes have been done"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:165
-msgid "Added home and root folder usage monitors"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:166
-msgid "Added layout selector"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:167
-msgid "Added Tips section"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:168
-msgid "Improve close and preferences buttons visibility when shown"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:174
-msgid "Under the hood tweaks"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:179
-msgid "Aesthetic:"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:180
-msgid "- Reworked graph drawing"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:181
-msgid "Internal:"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:182
-msgid "- Decoupled several events that can trigger a graph redraw"
-msgstr ""
-
-#: data/io.github.jorchube.monitorets.appdata.xml.in:187
-msgid "First release"
 msgstr ""
 
 #: data/io.github.jorchube.monitorets.desktop.in:10


### PR DESCRIPTION
## What?

- data: Mark release descriptions as untranslatable

## Why?

GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.

Also update the POT file.

## What?

- Add vcs-browser URL.
- Add translate URL.

## Why?

These URLs are visible on GNOME Control Center and Flathub.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url

